### PR TITLE
Add Direct-Sell-Output saving

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -2,7 +2,7 @@
 <modDesc descVersion="80">
   <author>Braeven</author>
   <contributors>Achimobil</contributors>
-  <version>1.5.0.0</version>
+  <version>1.5.0.1</version>
   <title>
     <en>Production Revamp</en>
   </title>


### PR DESCRIPTION
Fix for #18 .

Saving and loading productions that have production outputs stored from "forced" autosell by "sellDirectly=true".

Changes made: registered the relevant xml paths, and added the logic to the saveToXMLFile and loadFromXMLFile functions.